### PR TITLE
Probe discovered kernels with a heartbeat.

### DIFF
--- a/lib/jupyter.js
+++ b/lib/jupyter.js
@@ -75,15 +75,13 @@ IOPubSession.prototype.checkHealth = function (cb) {
       if (giveUp) { clearTimeout(giveUp); }
       cb(true);
     } else {
-      console.log(`Error: unexpected payload <${reply}>`);
+      console.error(`Error: unexpected payload <${reply}>`);
     }
   });
 
   this.heartbeatSocket.send(payload);
 
-  giveUp = setTimeout(2000, function () {
-    cb(false);
-  });
+  giveUp = setTimeout(function () { cb(false); }, 2000);
 };
 
 /**

--- a/lib/jupyter.js
+++ b/lib/jupyter.js
@@ -43,12 +43,6 @@ function IOPubSession(connectionJSON) {
       key = this.connectionJSON.key;
 
     /**
-     * Handles messages from the IOPub channel
-     * @member {messageCallback}
-     */
-    this.messageCallback = cb;
-
-    /**
      * Jupyter IOPub channel
      * @member {module:jmp~Socket}
      */

--- a/lib/jupyter.js
+++ b/lib/jupyter.js
@@ -1,9 +1,12 @@
+"use strict";
+
 module.exports = {
   IOPubSession: IOPubSession,
   RichDisplay: RichDisplay
 };
 
 var jmp = require("jmp");
+var zmq = require("zmq");
 var katex = require("katex");
 var marked = require("marked");
 var Convert = require('ansi-to-html');
@@ -27,14 +30,17 @@ function formConnectionString(config, channel) {
  * @class IOPubSession
  * @classdesc Keeps a session with an IOPub channel
  * @param {Object} connectionJSON Connection information provided by Jupyter
- * @param {messageCallback} messageCallback Callback that handles messages
  */
-function IOPubSession(connectionJSON, cb) {
+function IOPubSession(connectionJSON) {
   	/**
      * Connection information provided by Jupyter
      * @member {Object}
      */
     this.connectionJSON = connectionJSON;
+
+    var
+      hmac = this.connectionJSON.signature_scheme.slice("hmac-".length),
+      key = this.connectionJSON.key;
 
     /**
      * Handles messages from the IOPub channel
@@ -46,11 +52,7 @@ function IOPubSession(connectionJSON, cb) {
      * Jupyter IOPub channel
      * @member {module:jmp~Socket}
      */
-    this.iopubSocket = new jmp.Socket(
-         "sub",
-          this.connectionJSON.signature_scheme.slice("hmac-".length),
-          this.connectionJSON.key
-    );
+    this.iopubSocket = new jmp.Socket("sub", hmac, key);
 
     /**
      * URL for zmq socket
@@ -61,8 +63,48 @@ function IOPubSession(connectionJSON, cb) {
     this.iopubSocket.connect(this.iopubURL);
     this.iopubSocket.subscribe('');
 
-    this.iopubSocket.on("message", cb);
+    this.heartbeatSocket = new zmq.Socket("req");
+    this.heartbeatURL = formConnectionString(this.connectionJSON, "hb");
+    this.heartbeatSocket.connect(this.heartbeatURL);
 }
+
+/**
+ * Test the kernel's heartbeat to verify that it is (still) alive.
+ * @param {healthCallback} cb - Callback to invoke with the health of the kernel.
+ */
+IOPubSession.prototype.checkHealth = function (cb) {
+  const payload = "simple bytestrings, not full JSON messages described above";
+  let giveUp = null;
+
+  this.heartbeatSocket.once("message", function (reply) {
+    if (reply.toString() === payload) {
+      if (giveUp) { clearTimeout(giveUp); }
+      cb(true);
+    } else {
+      console.log(`Error: unexpected payload <${reply}>`);
+    }
+  });
+
+  this.heartbeatSocket.send(payload);
+
+  giveUp = setTimeout(2000, function () {
+    cb(false);
+  });
+};
+
+/**
+ * Register a callback to be fired when each Jupyter kernel IO message is received.
+ * @param {messageCallback} cb - Callback that handles messages
+ */
+IOPubSession.prototype.on = function (cb) {
+  this.iopubSocket.on("message", cb);
+};
+
+/**
+ * This callback reports whether or not a kernel is alive.
+ * @callback healthCallback
+ * @param {bool} True if the kernel has responded, false if it has not.
+ */
 
 /**
  * @class RichDisplay

--- a/main.js
+++ b/main.js
@@ -19,11 +19,11 @@ app.on('window-all-closed', function() {
   app.quit();
 });
 
-function launchSideCar(connFile) {
+function launchSideCar(ioSession) {
   // Keep a global reference of the side car window object
   // If we don't, the window will be closed automatically when the javascript
   // object is GCed.
-  var config = require(connFile);
+  let config = require(connPath);
   var sideCar = null;
   var session = null;
 
@@ -38,9 +38,8 @@ function launchSideCar(connFile) {
   // and load the index.html of the app.
   sideCar.loadUrl('file://' + __dirname + '/index.html');
 
-  sideCar.webContents.on('did-finish-load', function() {
-
-    session = new jupyter.IOPubSession(config, function(msg){
+  sideCar.webContents.on('did-finish-load', () => {
+    session.on((msg) => {
       if (!("header" in msg && "content" in msg)){
         // Didn't get a header, which is odd.
         // Also need content to display
@@ -74,7 +73,6 @@ function launchSideCar(connFile) {
           console.log("Noticed a msg_type we don't recognize");
           console.log(msg);
       }
-
     });
   });
 
@@ -98,21 +96,52 @@ function updateKernel(connFiles) {
       connStat = connFiles[i].stat;
 
     if (connStat.nlink !== 0) {
-      // This connection file is alive.
-      // If doesn't already have a sidecar, launch one for it.
-      if (! liveSidecars.has(connPath)) {
-        console.log("Launching sidecar for connection " + connPath + ".");
+      // This connection file is still present. Create a connection and probe its heartbeat to
+      // verify that the kernel is still responsive.
+      let config = require(connPath);
+      let session = new jupyter.IOPubSession(config);
 
-        liveSidecars.set(connPath, launchSideCar(connPath));
-      }
+      session.checkHealth((alive) => {
+        if (alive) {
+          handleLiveKernel(connPath, session);
+        } else {
+          handleDeadKernel(connPath);
+        }
+      });
     } else {
-      console.log("Connection " + connPath + " has been closed.");
-      if (liveSidecars.has(connPath)) {
-        console.log("Closing the corresponding sidecar.");
-        liveSidecars.get(connPath).close();
-        liveSidecars.delete(connPath);
-      }
+      handleDeadKernel(connPath);
     }
+  }
+}
+
+/**
+ * A kernel at the given connection path is alive and responding to heartbeat messages. Launch a
+ * new sidecar window if it does exist already.
+ *
+ * @param connPath {string} the filesystem path to the connection JSON file.
+ * @param session {jupyter.IOPubSession} an opened session to this kernel.
+ */
+function handleLiveKernel(connPath, session) {
+  if (! liveSidecars.has(connPath)) {
+    console.log("Launching sidecar for connection " + connPath + ".");
+    liveSidecars.set(connPath, launchSideCar(session));
+  }
+}
+
+/**
+ * A kernel connection JSON file has been deleted from the filesystem, or the kernel that a JSON
+ * file is referencing no longer responds to a heartbeat. Locate the sidecar window corresponding
+ * to this kernel and shut it down.
+ *
+ * @param connPath {string} the filesystem path to the connection JSON file.
+ */
+function handleDeadKernel(connPath) {
+  console.log("Connection " + connPath + " is no longer present.");
+
+  if (liveSidecars.has(connPath)) {
+    console.log("Closing the corresponding sidecar.");
+    liveSidecars.get(connPath).close();
+    liveSidecars.delete(connPath);
   }
 }
 

--- a/main.js
+++ b/main.js
@@ -38,7 +38,7 @@ function launchSideCar(ioSession) {
   sideCar.loadUrl('file://' + __dirname + '/index.html');
 
   sideCar.webContents.on('did-finish-load', function () {
-    session.on((msg) => {
+    session.on(function (msg) {
       if (!("header" in msg && "content" in msg)){
         // Didn't get a header, which is odd.
         // Also need content to display


### PR DESCRIPTION
Rather than assume that every connection file discovered by the watcher is a living kernel to attach to. This adds a check on the kernel heartbeat before continuing.

It also adds a few more zippy :rocket: ES6 features.