### PR TITLE
Move the display bits to a separate library.

### DIFF
--- a/lib/display-dispatch.js
+++ b/lib/display-dispatch.js
@@ -1,25 +1,17 @@
-module.exports = RichDisplay;
+module.exports = DisplayDispatch;
 
 /**
- * @class RichDisplay
- * @classdesc Assists in choosing the most rich display of the data
- * @param {Object} data The data field of an IOPub message's content (msg.content.data), keys are mimetypes
- *
- * MIME types supported (in display precedence):
- *   application/javascript
- *   text/html
- *   text/markdown
- *   text/latex
- *   image/svg+xml
- *   image/png
- *   image/jpeg
- *   application/json
- *   text/plain
+ * @class DisplayDispatch
+ * @classdesc Dispatches messages to a frontend
  */
-function RichDisplay () {
+function DisplayDispatch () {
 }
 
-RichDisplay.prototype.handleMessage = function (message, callbacks) {
+/**
+ * Handles messages according to the Jupyter Protocol
+ * @param {Object} message from a Jupyter backend
+ */
+DisplayDispatch.prototype.handleMessage = function (message, callbacks) {
   this.msg = message;
   this.content = message.content;
   this.data = message.content.data;
@@ -51,7 +43,7 @@ RichDisplay.prototype.handleMessage = function (message, callbacks) {
   }
 };
 
-RichDisplay.prototype.renderData = function(callbacks) {
+DisplayDispatch.prototype.renderData = function(callbacks) {
     // JavaScript is our most rich display type
     if ("application/javascript" in this.data) {
       var code = this.data["application/javascript"];
@@ -84,22 +76,22 @@ RichDisplay.prototype.renderData = function(callbacks) {
     callbacks.result(html);
 };
 
-RichDisplay.prototype.renderStream = function(callbacks) {
+DisplayDispatch.prototype.renderStream = function(callbacks) {
   callbacks.result(`<pre class='stream-${this.content.name}'>${this.content.text}</pre>`);
 };
 
-RichDisplay.prototype.updateStatus = function(webContents) {
+DisplayDispatch.prototype.updateStatus = function(webContents) {
   // TODO: Do something with the status (spinner anyone?)
   console.log(`Kernel ${this.content.execution_state}`);
 };
 
-RichDisplay.prototype.renderError = function(callbacks) {
+DisplayDispatch.prototype.renderError = function(callbacks) {
   var convert = new Convert({newline: true});
   var tracebackHTML = convert.toHtml(this.content.traceback);
 
   callbacks.trace(`<p style='font-family: monospace;'>${tracebackHTML}</p>`);
 };
 
-RichDisplay.prototype.renderUnimplemented = function(callbacks) {
+DisplayDispatch.prototype.renderUnimplemented = function(callbacks) {
   callbacks.result(`<h1><span style='font-family: monospace'>${this.msg.header.msg_type}</span> not implemented</h1><p style='font-family: monospace;'>${JSON.stringify(this.content)}</p>`);
 };

--- a/lib/display.js
+++ b/lib/display.js
@@ -1,0 +1,105 @@
+module.exports = RichDisplay;
+
+/**
+ * @class RichDisplay
+ * @classdesc Assists in choosing the most rich display of the data
+ * @param {Object} data The data field of an IOPub message's content (msg.content.data), keys are mimetypes
+ *
+ * MIME types supported (in display precedence):
+ *   application/javascript
+ *   text/html
+ *   text/markdown
+ *   text/latex
+ *   image/svg+xml
+ *   image/png
+ *   image/jpeg
+ *   application/json
+ *   text/plain
+ */
+function RichDisplay () {
+}
+
+RichDisplay.prototype.handleMessage = function (message, callbacks) {
+  this.msg = message;
+  this.content = message.content;
+  this.data = message.content.data;
+
+  switch(message.header.msg_type) {
+    case "execute_result":
+    case "display_data":
+      this.renderData(callbacks);
+      break;
+    case "stream":
+      this.renderStream(callbacks);
+      break;
+    case "status":
+      this.updateStatus(callbacks);
+      break;
+    case "error":
+      this.renderError(callbacks);
+      break;
+    case "execute_input":
+      // We don't do anything with execute_input for the moment
+      break;
+    case "comm_open":
+    case "comm_msg":
+      this.renderUnimplemented(callbacks);
+      break;
+    default:
+      console.log("Noticed a msg_type we don't recognize");
+      console.log(message);
+  }
+};
+
+RichDisplay.prototype.renderData = function(callbacks) {
+    // JavaScript is our most rich display type
+    if ("application/javascript" in this.data) {
+      var code = this.data["application/javascript"];
+      callbacks.execute(code);
+      return;
+    }
+
+    var html = null;
+
+    if("text/html" in this.data){
+      html = this.data["text/html"];
+    } else if ("text/markdown" in this.data) {
+      html = marked(this.data['text/markdown']);
+    } else if ("text/latex" in this.data) {
+      html = katex.renderToString(this.data["text/latex"]);
+    } else if ("image/svg+xml" in this.data) {
+      html = "<img src='data:image/svg+xml;base64," + this.data["image/svg+xml"] + "'/>";
+    } else if ("image/png" in this.data) {
+      html = "<img src='data:image/png;base64," + this.data["image/png"] + "'/>";
+    } else if ("image/jpeg" in this.data) {
+      html = "<img src='data:image/jpeg;base64," + this.data["image/jpeg"] + "'/>";
+    } else if ("application/json" in this.data) {
+      html = "<pre>" + JSON.stringify(this.data["application/json"]) + "</pre>";
+    } else if ("text/plain" in this.data) {
+      html = this.data["text/plain"];
+    } else {
+      console.log(this.data);
+    }
+
+    callbacks.result(html);
+};
+
+RichDisplay.prototype.renderStream = function(callbacks) {
+  callbacks.result(`<pre class='stream-${this.content.name}'>${this.content.text}</pre>`);
+};
+
+RichDisplay.prototype.updateStatus = function(webContents) {
+  // TODO: Do something with the status (spinner anyone?)
+  console.log(`Kernel ${this.content.execution_state}`);
+};
+
+RichDisplay.prototype.renderError = function(callbacks) {
+  var convert = new Convert({newline: true});
+  var tracebackHTML = convert.toHtml(this.content.traceback);
+
+  callbacks.trace(`<p style='font-family: monospace;'>${tracebackHTML}</p>`);
+};
+
+RichDisplay.prototype.renderUnimplemented = function(callbacks) {
+  callbacks.result(`<h1><span style='font-family: monospace'>${this.msg.header.msg_type}</span> not implemented</h1><p style='font-family: monospace;'>${JSON.stringify(this.content)}</p>`);
+};

--- a/lib/jupyter.js
+++ b/lib/jupyter.js
@@ -1,8 +1,7 @@
 "use strict";
 
 module.exports = {
-  IOPubSession: IOPubSession,
-  RichDisplay: RichDisplay
+  IOPubSession: IOPubSession
 };
 
 var jmp = require("jmp");
@@ -97,107 +96,3 @@ IOPubSession.prototype.on = function (cb) {
  * @callback healthCallback
  * @param {bool} True if the kernel has responded, false if it has not.
  */
-
-/**
- * @class RichDisplay
- * @classdesc Assists in choosing the most rich display of the data
- * @param {Object} data The data field of an IOPub message's content (msg.content.data), keys are mimetypes
- *
- * MIME types supported (in display precedence):
- *   application/javascript
- *   text/html
- *   text/markdown
- *   text/latex
- *   image/svg+xml
- *   image/png
- *   image/jpeg
- *   application/json
- *   text/plain
- */
-function RichDisplay () {
-}
-
-RichDisplay.prototype.handleMessage = function (message, callbacks) {
-  this.msg = message;
-  this.content = message.content;
-  this.data = message.content.data;
-
-  switch(message.header.msg_type) {
-    case "execute_result":
-    case "display_data":
-      this.renderData(callbacks);
-      break;
-    case "stream":
-      this.renderStream(callbacks);
-      break;
-    case "status":
-      this.updateStatus(callbacks);
-      break;
-    case "error":
-      this.renderError(callbacks);
-      break;
-    case "execute_input":
-      // We don't do anything with execute_input for the moment
-      break;
-    case "comm_open":
-    case "comm_msg":
-      this.renderUnimplemented(callbacks);
-      break;
-    default:
-      console.log("Noticed a msg_type we don't recognize");
-      console.log(message);
-  }
-};
-
-RichDisplay.prototype.renderData = function(callbacks) {
-    // JavaScript is our most rich display type
-    if ("application/javascript" in this.data) {
-      var code = this.data["application/javascript"];
-      callbacks.execute(code);
-      return;
-    }
-
-    var html = null;
-
-    if("text/html" in this.data){
-      html = this.data["text/html"];
-    } else if ("text/markdown" in this.data) {
-      html = marked(this.data['text/markdown']);
-    } else if ("text/latex" in this.data) {
-      html = katex.renderToString(this.data["text/latex"]);
-    } else if ("image/svg+xml" in this.data) {
-      html = "<img src='data:image/svg+xml;base64," + this.data["image/svg+xml"] + "'/>";
-    } else if ("image/png" in this.data) {
-      html = "<img src='data:image/png;base64," + this.data["image/png"] + "'/>";
-    } else if ("image/jpeg" in this.data) {
-      html = "<img src='data:image/jpeg;base64," + this.data["image/jpeg"] + "'/>";
-    } else if ("application/json" in this.data) {
-      html = "<pre>" + JSON.stringify(this.data["application/json"]) + "</pre>";
-    } else if ("text/plain" in this.data) {
-      html = this.data["text/plain"];
-    } else {
-      console.log(this.data);
-    }
-
-    callbacks.result(html);
-};
-
-RichDisplay.prototype.renderStream = function(callbacks) {
-  callbacks.result(`<pre class='stream-${this.content.name}'>${this.content.text}</pre>`);
-};
-
-RichDisplay.prototype.updateStatus = function(webContents) {
-  // TODO: Do something with the status (spinner anyone?)
-  console.log(`Kernel ${this.content.execution_state}`);
-};
-
-RichDisplay.prototype.renderError = function(callbacks) {
-  var convert = new Convert({newline: true});
-  var tracebackHTML = convert.toHtml(this.content.traceback);
-
-  callbacks.trace(`<p style='font-family: monospace;'>${tracebackHTML}</p>`);
-};
-
-RichDisplay.prototype.renderUnimplemented = function(callbacks) {
-  callbacks.result(`<h1><span style='font-family: monospace'>${this.msg.header.msg_type}</span> not implemented</h1><p style='font-family: monospace;'>${JSON.stringify(this.content)}</p>`);
-};

--- a/sidecar.js
+++ b/sidecar.js
@@ -1,9 +1,9 @@
 // This code executes within the sidecar window.
 
 var ipc = require('ipc');
-var jupyter = require('./lib/jupyter');
+var RichDisplay = require('./lib/display');
 
-var display = new jupyter.RichDisplay();
+var display = new RichDisplay();
 
 function appendNode(elementName, html) {
   var node = document.createElement(elementName);

--- a/sidecar.js
+++ b/sidecar.js
@@ -1,9 +1,9 @@
 // This code executes within the sidecar window.
 
 var ipc = require('ipc');
-var RichDisplay = require('./lib/display');
+var DisplayDispatch = require('./lib/display-dispatch');
 
-var display = new RichDisplay();
+var display = new DisplayDispatch();
 
 function appendNode(elementName, html) {
   var node = document.createElement(elementName);


### PR DESCRIPTION
There were issues when native code (zmq) was attempted to be loaded in the frontend, even
though it wasn't using it.

When booting `master`, got this error (and no ability to display outputs in sidecar):

`Unknown system error, uv_pipe_open`

https://github.com/atom/atom/issues/6632
https://github.com/atom/electron/issues/1429

This moves some of the display dispatch over to a separate file so there are no side effects from loading scripts with native modules.