### PR TITLE
Bring in KaTeX CSS using import

### DIFF
--- a/templates/sidecar-result.html
+++ b/templates/sidecar-result.html
@@ -1,7 +1,9 @@
 <!-- View component that includes the result of a single execution. -->
 
-<link rel="stylesheet" href="../bower_components/katex/dist/katex.min.css">
 <template id="tmpl-result">
+  <style>
+    @import "bower_components/katex/dist/katex.min.css";
+  </style>
   <style>
     #output-container {
       padding: 5px 10px;


### PR DESCRIPTION
The KaTeX CSS needed to be defined within the sidecar-result.

Since templates only let you define through `<style>`, I used a CSS `@import`.